### PR TITLE
[HPT-517] feat(attest): added product label for e-fact

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/dto/efact/InvoiceItem.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/dto/efact/InvoiceItem.kt
@@ -60,4 +60,5 @@ class InvoiceItem {
 
     var internshipNihii: String? = null
     var anatomy : String? = null
+    var productLabel: String? = null
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatWriter.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatWriter.kt
@@ -428,6 +428,7 @@ class BelgianInsuranceInvoicingFormatWriter(private val writer: Writer) {
         ws.write("33", icd.personalInterventionCoveredByThirdPartyCode?. let { if (it >= 0) it else 0 } ?: 0)//MAF Zone 33 todo //Mettre 1 si a charge du medecin
         ws.write("34", (icd.sideCode?: InvoicingSideCode.None).code)
         ws.write("35", sender.conventionCode)
+        ws.write("44", icd.productLabel)
         //47 conditional: before 01/07/2019 0000000, after 01/07/2019 +0000000
         ws.write("47",
             when {


### PR DESCRIPTION
Ticket: https://rosahealth.atlassian.net/browse/HPT-517
Added product label to the eFact request.
Users can now add a product label (description) to their request for eFact.

When a transparency code is linked to a non-reimbursable item (with a custom description), we now send the product label to eFact.

This value maps to zone 44, which is required in such cases to ensure correct processing.